### PR TITLE
Fix HackerRank::Candidate request

### DIFF
--- a/lib/hackerrank/candidate.rb
+++ b/lib/hackerrank/candidate.rb
@@ -1,6 +1,6 @@
 module HackerRank
   class Candidate < Base
-    collection_path -> (params) { "/tests/#{params[:test_id]}/candidates" }
+    collection_path -> (params) { "/tests/#{params.delete(:test_id)}/candidates" }
 
     def self.find_by_username(username, params)
       request :get, "/view", params, { username: username }

--- a/spec/candidate_spec.rb
+++ b/spec/candidate_spec.rb
@@ -16,9 +16,19 @@ describe HackerRank::Candidate do
   end
 
   describe ".find_by_username" do
+    let(:request) { HackerRank::Candidate.find_by_username 'dc.rec1@gmail.com', test_id: 12345 }
+
     it 'serializes the candidate by a test id and username' do
-      candidates = VCR.use_cassette('candidates_find_by_username')  { HackerRank::Candidate.find_by_username 'dc.rec1@gmail.com', test_id: 12345 }
+      candidates = VCR.use_cassette('candidates_find_by_username')  { request }
       expect(candidates['email']).to eql 'dc.rec1@gmail.com'
+    end
+
+    it 'sends request with empty body' do
+      expect(HTTParty).to receive(:get) do |url, params|
+        expect(params[:body]).to be_empty
+        {'data' => nil}
+      end
+      request
     end
   end
 

--- a/spec/cassettes/candidates_find_by_username.yml
+++ b/spec/cassettes/candidates_find_by_username.yml
@@ -4,8 +4,8 @@ http_interactions:
     method: get
     uri: https://www.hackerrank.com/x/api/v2/tests/12345/candidates/view?access_token=<HACKERRANK_ACCESS_TOKEN>&username=dc.rec1@gmail.com
     body:
-      encoding: UTF-8
-      string: test_id=12345
+      encoding: US-ASCII
+      string: ''
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -59,6 +59,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"data":{"email":"dc.rec1@gmail.com","tid":12345,"password":"54GRTt45","status":-1,"timestamp":"2015-07-08T15:02:46.000Z","link":"https://www.hackerrank.com/tests/54g45g4kjk5/login?b=t45g45g45kg45g45gplk45toj45toj45to45jt4tIiwicGFzc3dvcmQiOiIwYjhjN2MyZSJ9","metadata":null,"invite_details":{"invited_by":{"id":54541,"email":"EMAIL","name":"Contratado.ME"},"timestamp":"2015-07-08T15:02:46.000Z"}},"status":true,"message":"Success","http_status":200}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 07 Feb 2017 22:55:21 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
HackerRank::Candidate sent {test_id:1234} body with every request,
which caused errors during API request. Solution for this problem is to
send empty bodies.